### PR TITLE
Align left and added margin

### DIFF
--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -10074,10 +10074,11 @@ a.link-footer {
   font-style: normal;
   font-weight: normal;
   font-size: 0.85rem;
-  line-height: 200%;
+  line-height: 130%;
   color: #ffffff;
   width: fit-content;
-  text-align: center;
+  text-align: left;
+  margin-bottom: 10px;
 }
 
 a.link-footer:hover {


### PR DESCRIPTION
O menu do rodapé em telas pequenas estava com o texto centralizado, ficando muito desorganizado. alinhei para esquerda e também coloquei o espaçamento da quebra de linha diferente de texto quebrado. 